### PR TITLE
Use API Blueprint as a docs for a ToDo app API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ We use:
 
 * Express.js for routing
 * Sequelize for ORM
+* API Blueprint for API docs
 * React for client views
 
 ## Development
 
 In order to debug backend code in browser do several steps:
 
-  `cd server && yarn debug` 
+  `cd server && yarn debug`
 
   visit _about://inspect_ in Chrome and click *Open dedicated DevTools for Node* link
 

--- a/server/.env.sample
+++ b/server/.env.sample
@@ -1,4 +1,6 @@
 PORT=5000
+DB_USER=your-user-name-here
 DB_NAME=todo-list-db
 DB_PORT=5432
 DB_HOST=localhost
+NODE_ENV=development

--- a/server/api-docs.apib
+++ b/server/api-docs.apib
@@ -1,0 +1,56 @@
+FORMAT: 1A
+
+# TODO app API docs v1
+
+Note: all described endpoints should be used with `api/v1` prefix
+
+## Card Collection [/api/v1/cards]
+
+### POST
+Creates Card
+
+- Attributes (object)
+    + description (string, required)
+
+- Request (application/json)
+
+    - Body
+
+        ```
+        {
+          "description": "Homework"
+        }
+        ```
+
+- Response 201 (application/json; charset=utf-8)
+
+    - Attributes (object)
+        + id (number)
+        + description (string)
+        + updatedAt (string) - Timestamp of the last time the card was updated;
+        + createdAt (string) - Timestamp of the card creation.
+
+    - Body
+
+        ```
+        {
+          "id": 29,
+          "description": "Homework",
+          "updatedAt": "2018-12-05T16:44:29.408Z",
+          "createdAt": "2018-12-05T16:44:29.408Z"
+        }
+        ```
+
+- Request (application/json)
+
+    With invalid description (empty)
+
+    - Body
+
+        ```
+        {
+          "description": null
+        }
+        ```
+
+- Response 400 (application/json; charset=utf-8)


### PR DESCRIPTION
Here is [API Blueprint](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#def-response-section) setup: it does not require additional node module and gratefully previewed via github and text editors (you may need to setup extension, for ex: [sublime plugin](https://github.com/apiaryio/api-blueprint-sublime-plugin))

Props:
* [x] Docs can be viewed without html-file, just read markdown
![image](https://user-images.githubusercontent.com/3635774/49537168-55732000-f8d9-11e8-88be-e056571fdc27.png)

Note: markdown can be adjusted for better look and navigation

* [x] Dredd can be used for unit testing of endpoints (it takes info .apib file and runs specs based on response and request expecttions). Will be implemented in a separate PR