### PR TITLE
Fix bug with state updating in card

### DIFF
--- a/client/src/components/TodoCardList/Item/index.js
+++ b/client/src/components/TodoCardList/Item/index.js
@@ -7,7 +7,7 @@ const Item = props => (
     <Card>
       <CardBody className="text-left">
         <Input
-          checked={props.completedAt}
+          checked={props.completed}
           onClick={props.onChange}
           type="checkbox"
           label={props.description}
@@ -19,6 +19,7 @@ const Item = props => (
 
 Item.propTypes = {
   description: PropTypes.string.isRequired,
+  completed: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
 }
 

--- a/client/src/containers/TodoCardList/Item/index.js
+++ b/client/src/containers/TodoCardList/Item/index.js
@@ -5,7 +5,7 @@ import api from './requests'
 
 class TodoCardContainer extends Component {
   state = {
-    completed: this.props.completedAt ? true : false,
+    completed: !!this.props.completedAt,
   }
 
   render = () => (
@@ -21,7 +21,7 @@ class TodoCardContainer extends Component {
       api.card.completion.destroy(
         { id: this.props.id },
         () => {
-          this.setState({ completed: !this.state.completed })
+          this.setState(state => ({ completed: !state.completed }))
         },
         (error) => {
           alert(error)
@@ -31,7 +31,7 @@ class TodoCardContainer extends Component {
       api.card.completion.create(
         { id: this.props.id },
         () => {
-          this.setState({ completed: !this.state.completed })
+          this.setState(state => ({ completed: !state.completed }))
         },
         (error) => {
           alert(error)
@@ -43,7 +43,12 @@ class TodoCardContainer extends Component {
 
 TodoCardContainer.propTypes = {
   description: PropTypes.string.isRequired,
+  completedAt: PropTypes.string,
   id: PropTypes.number.isRequired,
+}
+
+TodoCardContainer.defaultProps = {
+  completedAt: '',
 }
 
 export default TodoCardContainer

--- a/client/src/containers/TodoCardList/Item/index.js
+++ b/client/src/containers/TodoCardList/Item/index.js
@@ -5,23 +5,23 @@ import api from './requests'
 
 class TodoCardContainer extends Component {
   state = {
-    completedAt: this.props.completedAt,
+    completed: this.props.completedAt ? true : false,
   }
 
   render = () => (
     <TodoCard
       description={this.props.description}
-      completedAt={this.state.completedAt}
+      completed={this.state.completed}
       onChange={this.updateCompletedAt}
     />
   );
 
   updateCompletedAt = () => {
-    if (this.isCompleted()) {
+    if (this.state.completed) {
       api.card.completion.destroy(
         { id: this.props.id },
         () => {
-          this.setState({ completedAt: null })
+          this.setState({ completed: !this.state.completed })
         },
         (error) => {
           alert(error)
@@ -30,8 +30,8 @@ class TodoCardContainer extends Component {
     } else {
       api.card.completion.create(
         { id: this.props.id },
-        (response) => {
-          this.setState({ completedAt: response.card.completedAt })
+        () => {
+          this.setState({ completed: !this.state.completed })
         },
         (error) => {
           alert(error)
@@ -39,9 +39,6 @@ class TodoCardContainer extends Component {
       )
     }
   }
-
-  isCompleted = () =>
-    this.state.completedAt != null
 }
 
 TodoCardContainer.propTypes = {


### PR DESCRIPTION
DEMO:
https://www.youtube.com/watch?v=2V-Vok3leOc&feature=youtu.be
So, now it works without any errors or warnings in console.
I think that problem was in `null`, it worked unpredictably. Now everything is transparent, we work with boolean. 
**BUT** 
I get lint errors
<img width="711" alt="2018-12-17 23 16 50" src="https://user-images.githubusercontent.com/32716983/50113024-daebbe00-0251-11e9-826f-a88f401c860a.png">
1) Old error, that appears because we sent `completedAt` in props as `null` if it wasn't complete yet.
2) It looks like `completed: this.props.completedAt ? true : false,` works like just `completed: this.props.completedAt`. But this is not so. So, if we use second way this lint error will fixed, but we will see ugly warning in console
<img width="641" alt="2018-12-17 23 26 02" src="https://user-images.githubusercontent.com/32716983/50113588-6dd92800-0253-11e9-8c93-83dad11dfdd8.png">
That happens because we use props in state, in the Internet about this write that if we use props only for initializing of state it is okay to use props in state, but in other way it is anti-pattern. 

3 - 4) It is just don't like that we reference the previous state and set it in one place, I don't understand a bit what it wants.

So, what do you think about it?
 
