### PR TITLE
Run dredd testing via one command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ For endpoints system-testing we use [Dredd](https://dredd.org/en/latest/) and [a
 
 How to run:
 
-* Start dev server in testing mode via `yarn dev:test`
-* Call `yarn test:api` for running test suites
+* Call `yarn test:api`
+  (it runs dredd tests and kills server process)
 
 Note: all Dredd hooks' files have .hook.js postfix
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ For endpoints system-testing we use [Dredd](https://dredd.org/en/latest/) and [a
 
 How to run:
 
-* Start dev server in testing mode via `yarn dev-test`
-* Call `yarn test-api` for running test suites
+* Start dev server in testing mode via `yarn dev:test`
+* Call `yarn test:api` for running test suites
 
 Note: all Dredd hooks' files have .hook.js postfix
 

--- a/server/.babelrc
+++ b/server/.babelrc
@@ -1,3 +1,11 @@
 {
-  "presets": ["@babel/preset-env"]
+  "presets": [
+    [
+      "@babel/preset-env", {
+        "targets": {
+          "node": "current"
+        }
+      }
+    ]
+  ]
 }

--- a/server/dredd.yml
+++ b/server/dredd.yml
@@ -2,6 +2,7 @@ dry-run: null
 hookfiles: ./**/*.hook.js
 language: nodejs
 sandbox: false
+server: yarn dev:test
 server-wait: 3
 init: false
 custom: {}

--- a/server/package.json
+++ b/server/package.json
@@ -3,16 +3,23 @@
   "version": "0.1.0",
   "description": "ToDo app API",
   "main": "build",
+  "config": {
+    "test_port": "8000"
+  },
   "private": true,
   "scripts": {
     "dev": "nodemon -w src --exec \"babel-node src\"",
-    "dev-test": "NODE_ENV=test PORT=8000 yarn dev",
+    "dev:test": "NODE_ENV=test PORT=$npm_package_config_test_port babel-node src",
     "debug": "nodemon -w src src/index.js --exec 'babel-node --inspect'",
-    "build": "babel src -s -D -d build",
-    "start": "node build",
+
+    "test": "yarn test:api",
+    "test:api": "yarn test:dredd",
+    "test:dredd": "babel-node node_modules/.bin/dredd",
+
     "lint": "eslint src",
-    "test": "NODE_ENV=test yarn jasmine",
-    "test-api": "NODE_ENV=test babel-node node_modules/.bin/dredd"
+
+    "build": "babel src -d build",
+    "start": "node build"
   },
   "dependencies": {
     "body-parser": "^1.13.3",

--- a/server/package.json
+++ b/server/package.json
@@ -10,10 +10,11 @@
   "scripts": {
     "dev": "nodemon -w src --exec \"babel-node src\"",
     "dev:test": "NODE_ENV=test PORT=$npm_package_config_test_port babel-node src",
+    "dev:test:kill": "lsof -t -i:$npm_package_config_test_port | xargs kill -15 | xargs kill -9",
     "debug": "nodemon -w src src/index.js --exec 'babel-node --inspect'",
 
     "test": "yarn test:api",
-    "test:api": "yarn test:dredd",
+    "test:api": "yarn test:dredd; yarn dev:test:kill",
     "test:dredd": "babel-node node_modules/.bin/dredd",
 
     "lint": "eslint src",

--- a/server/src/config.json
+++ b/server/src/config.json
@@ -1,5 +1,0 @@
-{
-	"port": 5000,
-	"bodyLimit": "100kb",
-	"corsHeaders": ["Link"]
-}

--- a/server/src/config/server.js
+++ b/server/src/config/server.js
@@ -1,0 +1,7 @@
+require('dotenv').config()
+
+module.exports = {
+  port: process.env.PORT || 5000,
+  bodyLimit: '100kb',
+  corsHeaders: ['Link']
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -5,9 +5,7 @@ import morgan from 'morgan'
 import bodyParser from 'body-parser'
 import middleware from './middleware'
 import apiRouter from './routes/v1'
-import config from './config.json'
-
-require('dotenv').config()
+import config from './config/server'
 
 const app = express()
 app.server = http.createServer(app)
@@ -29,8 +27,8 @@ app.use('/api/v1', apiRouter)
 // internal middleware
 app.use(middleware())
 
-app.server.listen(process.env.PORT || config.port, () => {
-  console.log(`Started ${process.env.NODE_ENV} env on port ${app.server.address().port}`)
+app.server.listen(config.port, () => {
+  console.log(`Started ${process.env.NODE_ENV} env on port ${config.port}`)
 })
 
 export default app

--- a/server/src/models/card/mock.js
+++ b/server/src/models/card/mock.js
@@ -4,7 +4,7 @@ const dbMock = new SequelizeDBMock()
 
 module.exports = () => {
   const Card = dbMock.define('Card', {
-    description: 'Homеwork'
+    description: 'Homеwork',
   })
 
   return Card


### PR DESCRIPTION
Here is a discussion of a problem: https://datarockets.slack.com/archives/CDZ3G2D8R/p1545332621036100

**Changes**:

* [x] Fix babel node src compilation for production
* [x] Move server configs to separate file
* [x] Use [standard way](https://www.keithcirkel.co.uk/how-to-use-npm-as-a-build-tool/) for managing package scripts
* [x] Run dredd tests via one command