### PR TITLE
Fix linter errors of importing

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -1,8 +1,0 @@
-{
-  "extends": "datarockets",
-  "rules": {
-    "no-console": 0,
-    "import/no-unresolved": 0,
-    "no-alert": 0,
-  }
-}

--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -3,6 +3,6 @@
   "rules": {
     "no-console": 0,
     "import/no-unresolved": 0,
-    "no-alert": 0
+    "no-alert": 0,
   }
 }

--- a/client/.eslintrc.yml
+++ b/client/.eslintrc.yml
@@ -1,0 +1,5 @@
+extends: datarockets
+rules:
+  no-console: 0
+  import/no-unresolved: 0
+  no-alert: 0

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -1,12 +1,10 @@
 import React from 'react'
 import './styles.css'
 
-function Header() {
-  return (
-    <div className="header">
-      <h1>TODO list</h1>
-    </div>
-  )
-}
+const Header = () => (
+  <div className="header">
+    <h1>TODO list</h1>
+  </div>
+)
 
 export default Header

--- a/client/src/components/TodoCardList/index.js
+++ b/client/src/components/TodoCardList/index.js
@@ -6,16 +6,14 @@ import TodoCard from 'src/components/TodoCardList/Item'
 const TodoCardList = props => (
   <div className="col-sm-3 mx-auto">
     {
-      props.items.map(
-        todoCard => (
-          <TodoCardContainer
-            key={todoCard.id}
-            id={todoCard.id}
-            description={todoCard.description}
-            completedAt={todoCard.completedAt}
-          />
-        ),
-      )
+      props.items.map(todoCard => (
+        <TodoCardContainer
+          key={todoCard.id}
+          id={todoCard.id}
+          description={todoCard.description}
+          completedAt={todoCard.completedAt}
+        />
+      ))
     }
   </div>
 )

--- a/client/src/containers/App/index.js
+++ b/client/src/containers/App/index.js
@@ -9,8 +9,8 @@ class AppContainer extends Component {
 
   componentDidMount() {
     api.cards.getAll(
-      (response) => { this.setState({ todoCards: response.data }) },
-      (error) => { alert(error) },
+      response => { this.setState({ todoCards: response.data }) },
+      error => { alert(error) },
     )
   }
 
@@ -21,7 +21,7 @@ class AppContainer extends Component {
     />
   )
 
-  addTodoCard = (card) => {
+  addTodoCard = card => {
     this.setState(state => ({ todoCards: [...state.todoCards, card] }))
   }
 }

--- a/client/src/containers/App/index.js
+++ b/client/src/containers/App/index.js
@@ -9,8 +9,8 @@ class AppContainer extends Component {
 
   componentDidMount() {
     api.cards.getAll(
-      response => { this.setState({ todoCards: response.data }) },
-      error => { alert(error) },
+      response => this.setState({ todoCards: response.data }),
+      error => alert(error),
     )
   }
 
@@ -21,9 +21,8 @@ class AppContainer extends Component {
     />
   )
 
-  addTodoCard = card => {
+  addTodoCard = card =>
     this.setState(state => ({ todoCards: [...state.todoCards, card] }))
-  }
 }
 
 export default AppContainer

--- a/client/src/containers/CreateCardForm/index.js
+++ b/client/src/containers/CreateCardForm/index.js
@@ -19,7 +19,7 @@ class CreateCardFormContainer extends Component {
   setDescription = event =>
     this.setState({ description: event.target.value })
 
-  createCard = event => {
+  createCard = (event) => {
     event.preventDefault()
     api.cards.create(
       { description: this.state.description },

--- a/client/src/containers/CreateCardForm/index.js
+++ b/client/src/containers/CreateCardForm/index.js
@@ -16,20 +16,15 @@ class CreateCardFormContainer extends Component {
     />
   );
 
-  setDescription = (event) => {
+  setDescription = event =>
     this.setState({ description: event.target.value })
-  }
 
-  createCard = (event) => {
+  createCard = event => {
     event.preventDefault()
     api.cards.create(
       { description: this.state.description },
-      (response) => {
-        this.props.onCreate(response.data)
-      },
-      (error) => {
-        alert(error)
-      },
+      response => this.props.onCreate(response.data),
+      error => alert(error),
     )
   }
 }

--- a/client/src/containers/TodoCardList/Item/index.js
+++ b/client/src/containers/TodoCardList/Item/index.js
@@ -23,7 +23,7 @@ class TodoCardContainer extends Component {
         () => {
           this.setState(state => ({ completed: !state.completed }))
         },
-        (error) => {
+        error => {
           alert(error)
         },
       )
@@ -33,7 +33,7 @@ class TodoCardContainer extends Component {
         () => {
           this.setState(state => ({ completed: !state.completed }))
         },
-        (error) => {
+        error => {
           alert(error)
         },
       )

--- a/client/src/containers/TodoCardList/Item/index.js
+++ b/client/src/containers/TodoCardList/Item/index.js
@@ -20,22 +20,14 @@ class TodoCardContainer extends Component {
     if (this.state.completed) {
       api.card.completion.destroy(
         { id: this.props.id },
-        () => {
-          this.setState(state => ({ completed: !state.completed }))
-        },
-        error => {
-          alert(error)
-        },
+        () => this.setState(state => ({ completed: !state.completed })),
+        error => alert(error),
       )
     } else {
       api.card.completion.create(
         { id: this.props.id },
-        () => {
-          this.setState(state => ({ completed: !state.completed }))
-        },
-        error => {
-          alert(error)
-        },
+        () => this.setState(state => ({ completed: !state.completed })),
+        error => alert(error),
       )
     }
   }

--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -2,6 +2,7 @@
   "extends": "datarockets-base",
   "rules": {
     "no-console": 0,
-    "no-unused-vars": ["error", { "argsIgnorePattern": "next" }]
+    "no-unused-vars": ["error", { "argsIgnorePattern": "next" }],
+    "import/no-extraneous-dependencies": ["error", {"devDependencies": true}],
   }
 }

--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -1,8 +1,0 @@
-{
-  "extends": "datarockets-base",
-  "rules": {
-    "no-console": 0,
-    "no-unused-vars": ["error", { "argsIgnorePattern": "next" }],
-    "import/no-extraneous-dependencies": ["error", {"devDependencies": true}],
-  }
-}

--- a/server/.eslintrc.yml
+++ b/server/.eslintrc.yml
@@ -1,0 +1,9 @@
+extends: datarockets-base
+rules:
+  no-console: 0
+  import/no-extraneous-dependencies:
+    - error
+    - devDependencies: true
+settings:
+  import/ignore:
+    - models/index

--- a/server/src/config/server.js
+++ b/server/src/config/server.js
@@ -3,5 +3,5 @@ require('dotenv').config()
 module.exports = {
   port: process.env.PORT || 5000,
   bodyLimit: '100kb',
-  corsHeaders: ['Link']
+  corsHeaders: ['Link'],
 }

--- a/server/src/controllers/v1/cards.js
+++ b/server/src/controllers/v1/cards.js
@@ -7,21 +7,21 @@ module.exports = {
         description: req.body.description,
         raw: true,
       })
-      .then((card) => { res.status(201).send(card) })
-      .catch((error) => { res.status(400).send(error) })
+      .then(card => res.status(201).send(card))
+      .catch(error => res.status(400).send(error))
   },
 
   destroy: (req, res) => {
     Card
       .findByPk(req.params.id)
       .then(card => card.destroy())
-      .then(() => { res.status(204).send() })
-      .catch(() => { res.status(400).send({ error: 'Bad Request', message: 'Card not found' }) })
+      .then(() => res.status(204).send())
+      .catch(() => res.status(400).send({ error: 'Bad Request', message: 'Card not found' }))
   },
 
   getAll: (req, res) => {
     Card.findAll({ raw: true })
-      .then((cards) => { res.status(200).send(cards) })
-      .catch((error) => { res.status(400).send(error) })
+      .then(cards => res.status(200).send(cards))
+      .catch(error => res.status(400).send(error))
   },
 }

--- a/server/src/controllers/v1/cards.js
+++ b/server/src/controllers/v1/cards.js
@@ -12,8 +12,7 @@ module.exports = {
   },
 
   destroy: (req, res) => {
-    Card
-      .findByPk(req.params.id)
+    Card.findByPk(req.params.id)
       .then(card => card.destroy())
       .then(() => res.status(204).send())
       .catch(() => res.status(400).send({ error: 'Bad Request', message: 'Card not found' }))

--- a/server/src/controllers/v1/cards/completion.js
+++ b/server/src/controllers/v1/cards/completion.js
@@ -7,13 +7,13 @@ module.exports = {
       .then((card) => {
         res.status(201).send({ card: { completedAt: card.completedAt } })
       })
-      .catch((error) => { res.status(400).send(error) })
+      .catch(error => res.status(400).send(error))
   },
 
   destroy: (req, res) => {
     Card.findByPk(req.params.id)
       .then(card => card.uncomplete())
-      .then(() => { res.status(204).send() })
-      .catch((error) => { res.status(400).send(error) })
+      .then(() => res.status(204).send())
+      .catch(error => res.status(400).send(error))
   },
 }

--- a/server/src/routes/v1/cards.js
+++ b/server/src/routes/v1/cards.js
@@ -1,8 +1,7 @@
 const cardsController = require('../../controllers/v1').cards
 
-module.exports = (router) => {
+module.exports = router =>
   router
     .post('/cards', cardsController.create)
     .delete('/cards/:id', cardsController.destroy)
     .get('/cards', cardsController.getAll)
-}

--- a/server/src/routes/v1/cards/completion.js
+++ b/server/src/routes/v1/cards/completion.js
@@ -1,7 +1,6 @@
 const completionController = require('../../../controllers/v1').cardCompletion
 
-module.exports = (router) => {
+module.exports = router =>
   router
     .post('/cards/:id/completion', completionController.create)
     .delete('/cards/:id/completion', completionController.destroy)
-}


### PR DESCRIPTION
**Changes**
* [x] Update arrow style requirements for both server and client

Means:

use 
```js
.then(cards => res.status(200).send(cards))
```

instead of
```js
.then(cards => { res.status(200).send(cards) })
```

Eslint do not cover rule of not using `{}` parens for one-line arrow function, so we can agreed to use it like that, and we can add separate rule for that later, Thoughts?

--------------------------------

* [x] Ignore import errors related to models/index exporting

Just ignore, can't be fixed because we use dynamic export. The rule expects explicit export, kind of:

```js
models/index.js

...

module.export = {
  ...
  Card,
  AnotherModel,
  OneMoreModel,
}
```

But it's not cool to add models all the time, that's why we just use:

```js
module.export = db
```

for now