### PR TITLE
Setup circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
-version: 2
+version: 2.1
 
 jobs:
-  build-client:
+  bundle-client-dependencies:
     working_directory: ~/loopback-to-do/client
     docker:
       - image: circleci/node:11.6
@@ -21,7 +21,7 @@ jobs:
           root: .
           paths:
             - node_modules
-  build-server:
+  bundle-server-dependencies:
     working_directory: ~/loopback-to-do/server
     docker:
       - image: circleci/node:11.6
@@ -89,18 +89,18 @@ jobs:
           name: Test server
           command: yarn test:dredd
 workflows:
-  version: 2
+  version: 2.1
   build_test_and_lint:
     jobs:
-      - build-client
-      - build-server
+      - bundle-client-dependencies
+      - bundle-server-dependencies
       - lint-client:
           requires:
-            - build-client
+            - bundle-client-dependencies
       - lint-server:
           requires:
-            - build-server
+            - bundle-server-dependencies
       - test-server:
           requires:
-            - build-server
+            - bundle-server-dependencies
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,106 @@
+version: 2
+
+jobs:
+  build-client:
+    working_directory: ~/loopback-to-do/client
+    docker:
+      - image: circleci/node:11.6
+    steps:
+      - checkout:
+          path: ~/loopback-to-do
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: Client setup
+          command: yarn
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+      - persist_to_workspace:
+          root: .
+          paths:
+            - node_modules
+  build-server:
+    working_directory: ~/loopback-to-do/server
+    docker:
+      - image: circleci/node:11.6
+    steps:
+      - checkout:
+          path: ~/loopback-to-do
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: Server setup
+          command: yarn
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+      - persist_to_workspace:
+          root: .
+          paths:
+            - node_modules
+  lint-client:
+    working_directory: ~/loopback-to-do/client
+    docker:
+      - image: circleci/node:11.6
+    steps:
+      - checkout:
+          path: ~/loopback-to-do
+      - attach_workspace:
+          at: ~/loopback-to-do/client
+      - run:
+          name: Lint client
+          command: ./node_modules/.bin/eslint src
+  lint-server:
+    working_directory: ~/loopback-to-do/server
+    docker:
+      - image: circleci/node:11.6
+    steps:
+      - checkout:
+          path: ~/loopback-to-do
+      - attach_workspace:
+          at: ~/loopback-to-do/server
+      - run:
+          name: Lint server
+          command: ./node_modules/.bin/eslint src
+  test-server:
+    working_directory: ~/loopback-to-do/server
+    docker:
+      - image: circleci/node:11.6
+        environment:
+          PGUSER: postgres
+      - image: circleci/postgres:10-alpine-postgis
+        environment:
+          POSTGRES_USER: postgres
+    steps:
+      - checkout:
+          path: ~/loopback-to-do
+      - attach_workspace:
+          at: ~/loopback-to-do/server
+      - run:
+          name: Create DB
+          command: NODE_ENV=test node_modules/.bin/sequelize db:create
+      - run:
+          name: Run migrations
+          command: NODE_ENV=test node_modules/.bin/sequelize db:migrate
+      - run:
+          name: Test server
+          command: yarn test:dredd
+workflows:
+  version: 2
+  build_test_and_lint:
+    jobs:
+      - build-client
+      - build-server
+      - lint-client:
+          requires:
+            - build-client
+      - lint-server:
+          requires:
+            - build-server
+      - test-server:
+          requires:
+            - build-server
+      


### PR DESCRIPTION
It was painful, but everything seems to work. 😌
<img width="1015" alt="screen shot 2018-12-29 at 15 43 06" src="https://user-images.githubusercontent.com/32716983/50538619-10ae7200-0b83-11e9-8795-0266544e4d68.png">
<img width="504" alt="screen shot 2018-12-29 at 15 43 28" src="https://user-images.githubusercontent.com/32716983/50538620-12783580-0b83-11e9-9915-5844402bc26c.png">

So, as it turned out, circleci not very friendly with 2 applications at once. There were problems with sharing of node_modules between jobs, because we work with 2 packages and 2 node_modules folder. I had to use:
```
- persist_to_workspace:
          root: .
          paths:
            - node_modules
```
and
```
- attach_workspace:
          at: ~/loopback-to-do/client
```
to share node_modules between jobs.

Also I had to write scripts for the server, and not use `yarn setup`, because we don't need dev DB for testing and setup script do everything at once: download packages, create DB, etc, but we need split this to separate jobs.