### PR TITLE
Use unnamed functions as a default

### DIFF
--- a/server/.eslintrc.yml
+++ b/server/.eslintrc.yml
@@ -4,6 +4,9 @@ rules:
   import/no-extraneous-dependencies:
     - error
     - devDependencies: true
+  func-names:
+    - error
+    - never
 settings:
   import/core-modules:
     - hooks

--- a/server/spec/system/endpoints/index.hook.js
+++ b/server/spec/system/endpoints/index.hook.js
@@ -1,5 +1,4 @@
 import 'app-module-path/cwd'
-
 import { beforeAll, afterAll } from 'hooks'
 import db from 'src/models'
 

--- a/server/src/models/card/model.js
+++ b/server/src/models/card/model.js
@@ -4,11 +4,11 @@ module.exports = (sequelize, DataTypes) => {
     completedAt: { type: DataTypes.DATE, allowNull: true },
   }, {})
 
-  Card.prototype.complete = function complete() {
+  Card.prototype.complete = function () {
     return this.update({ completedAt: Date.now() })
   }
 
-  Card.prototype.uncomplete = function uncomplete() {
+  Card.prototype.uncomplete = function () {
     return this.update({ completedAt: null })
   }
 


### PR DESCRIPTION
**Changes**
* [x] Use unnamed functions as a default

[Rule page](https://eslint.org/docs/rules/func-names). Pattern of using names for functions was added in order to see good debug messages, but we still see understandable messages because of such style:

```js
Card.prototype.complete = ...
```

That's why we lose nothing with `never` option